### PR TITLE
Add timeouts to remote downloads

### DIFF
--- a/Prj-Python/hyperlpr3/command/sample.py
+++ b/Prj-Python/hyperlpr3/command/sample.py
@@ -27,7 +27,7 @@ def is_http_url(s):
 
 def url_to_image(url):
     try:
-        resp = urllib.request.urlopen(url)
+        resp = urllib.request.urlopen(url, timeout=10)
         image = np.asarray(bytearray(resp.read()), dtype="uint8")
         image = cv2.imdecode(image, cv2.IMREAD_COLOR)
     except Exception as err:

--- a/Prj-Python/hyperlpr3/command/sample.py
+++ b/Prj-Python/hyperlpr3/command/sample.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import hyperlpr3 as lpr3
 import cv2
-import urllib
+import urllib.error
+import urllib.request
 import numpy as np
 import re
 import click
@@ -30,7 +31,11 @@ def url_to_image(url):
         resp = urllib.request.urlopen(url, timeout=10)
         image = np.asarray(bytearray(resp.read()), dtype="uint8")
         image = cv2.imdecode(image, cv2.IMREAD_COLOR)
+    except urllib.error.URLError as err:
+        logger.warning(f"Failed to fetch image from URL ({err}): {url}")
+        return None
     except Exception as err:
+        logger.warning(f"Unexpected error reading image from URL: {err}")
         return None
 
     return image

--- a/Prj-Python/hyperlpr3/config/configuration.py
+++ b/Prj-Python/hyperlpr3/config/configuration.py
@@ -4,9 +4,12 @@ import zipfile
 import os
 from .settings import _DEFAULT_FOLDER_, _MODEL_VERSION_, _ONLINE_URL_, _REMOTE_URL_, onnx_model_maps, onnx_runtime_config
 
+REQUEST_TIMEOUT_SECONDS = 30
+
 
 def down_model_file(url, save_path):
-    resp = requests.get(url, stream=True)
+    resp = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT_SECONDS)
+    resp.raise_for_status()
     total = int(resp.headers.get('content-length', 0))
     with open(save_path, 'wb') as file, tqdm(
             desc="Pull",
@@ -21,7 +24,8 @@ def down_model_file(url, save_path):
 
 
 def down_model_zip(url, save_path, is_unzip=False):
-    resp = requests.get(url, stream=True)
+    resp = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT_SECONDS)
+    resp.raise_for_status()
     total = int(resp.headers.get('content-length', 0))
     name = os.path.join(save_path, os.path.basename(url))
     with open(name, 'wb') as file, tqdm(
@@ -60,4 +64,3 @@ def initialization(re_download=False):
     if not os.path.exists(models_dir) or re_download:
         target_url = os.path.join(_ONLINE_URL_, _MODEL_VERSION_) + '.zip'
         down_model_zip(target_url, _DEFAULT_FOLDER_, True)
-

--- a/Prj-Python/hyperlpr3/config/configuration.py
+++ b/Prj-Python/hyperlpr3/config/configuration.py
@@ -11,16 +11,21 @@ def down_model_file(url, save_path):
     resp = requests.get(url, stream=True, timeout=REQUEST_TIMEOUT_SECONDS)
     resp.raise_for_status()
     total = int(resp.headers.get('content-length', 0))
-    with open(save_path, 'wb') as file, tqdm(
-            desc="Pull",
-            total=total,
-            unit='iB',
-            unit_scale=True,
-            unit_divisor=1024,
-    ) as bar:
-        for data in resp.iter_content(chunk_size=1024):
-            size = file.write(data)
-            bar.update(size)
+    try:
+        with open(save_path, 'wb') as file, tqdm(
+                desc="Pull",
+                total=total,
+                unit='iB',
+                unit_scale=True,
+                unit_divisor=1024,
+        ) as bar:
+            for data in resp.iter_content(chunk_size=1024):
+                size = file.write(data)
+                bar.update(size)
+    except Exception:
+        if os.path.exists(save_path):
+            os.remove(save_path)
+        raise
 
 
 def down_model_zip(url, save_path, is_unzip=False):
@@ -28,16 +33,21 @@ def down_model_zip(url, save_path, is_unzip=False):
     resp.raise_for_status()
     total = int(resp.headers.get('content-length', 0))
     name = os.path.join(save_path, os.path.basename(url))
-    with open(name, 'wb') as file, tqdm(
-            desc="Pull",
-            total=total,
-            unit='iB',
-            unit_scale=True,
-            unit_divisor=1024,
-    ) as bar:
-        for data in resp.iter_content(chunk_size=1024):
-            size = file.write(data)
-            bar.update(size)
+    try:
+        with open(name, 'wb') as file, tqdm(
+                desc="Pull",
+                total=total,
+                unit='iB',
+                unit_scale=True,
+                unit_divisor=1024,
+        ) as bar:
+            for data in resp.iter_content(chunk_size=1024):
+                size = file.write(data)
+                bar.update(size)
+    except Exception:
+        if os.path.exists(name):
+            os.remove(name)
+        raise
 
     if is_unzip:
         f = zipfile.ZipFile(name, "r")


### PR DESCRIPTION
## Summary
- add explicit timeouts to remote model download requests
- fail fast on HTTP errors before streaming response bodies
- add a timeout when loading sample images from URLs

## Why
The download helpers currently wait indefinitely if a remote server stalls. Adding bounded timeouts keeps CLI/model initialization paths from hanging on network sockets, while raise_for_status makes failed downloads explicit before writing partial content.

## Testing
- python3 -m py_compile Prj-Python/hyperlpr3/config/configuration.py Prj-Python/hyperlpr3/command/sample.py
- git diff --check